### PR TITLE
Fix inadvertent glibc upgrade

### DIFF
--- a/tasks/apt_build_depends.yml
+++ b/tasks/apt_build_depends.yml
@@ -1,5 +1,5 @@
 - name: install build depends
-  apt: pkg={{ item }} state=latest install_recommends=no
+  apt: pkg={{ item }} state=present install_recommends=no
   with_items:
     - build-essential
     - git

--- a/tasks/homebrew_build_depends.yml
+++ b/tasks/homebrew_build_depends.yml
@@ -1,10 +1,10 @@
 ---
-- homebrew: name={{ item }} state=latest
+- homebrew: name={{ item }} state=present
   with_items:
     - openssl
     - libyaml
 # required for building Ruby <= 1.9.3-p0
 - homebrew_tap: tap=homebrew/dupes state=present
   when: rbenv.ruby_version <= 1.9.3-p0
-- homebrew: name=apple-gcc42 state=latest
+- homebrew: name=apple-gcc42 state=present
   when: rbenv.ruby_version <= 1.9.3-p0

--- a/tasks/yum_build_depends.yml
+++ b/tasks/yum_build_depends.yml
@@ -1,6 +1,6 @@
 ---
 - name: install build depends
-  yum: name={{ item }} state=latest
+  yum: name={{ item }} state=present
   with_items:
     - gcc
     - openssl-devel


### PR DESCRIPTION
Apparently in Ansible, `state=latest` is equivalent to performing an `upgrade` of the packages we are installing with the package manager modules. (I'm new to Ansible, so didn't realize this about `state=latest`.  In Chef, the equivalent would be: `package 'foo'` with `action :upgrade`.  The default action is `:install` which just installs the latest version of the package... but does **not** upgrade it!)

So you might be wondering why this really matters...
The problem with this is that we are specifying to upgrade all the build essential packages which includes glibc, which **many** programs and packages on the system rely on, and are linked against.  So upgrading glibc along with all the build dependencies is a non-trivial operation and in most cases is not what we want to be doing here.  Instead we want to just do what `action :install` would do in Chef, which is `state=present` in Ansible-speak.
