### PR TITLE
Do not report changed for checking installed ruby version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,6 +115,7 @@
 - name: check ruby {{ rbenv.ruby_version }} installed
   shell: bash -lc "rbenv versions | grep {{ rbenv.ruby_version }}"
   register: ruby_installed
+  changed_when: false
   ignore_errors: yes
   tags:
     - rbenv


### PR DESCRIPTION
Very minor annoyance, this task always shows up as changed.

Seems to me that it's safe to always report it as not changed since it's not affecting machine state.
