### PR TITLE
Add the option to use a custom default-gems file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Description:
 - ` rbenv_plugins ` - Array of Hashes with information about plugins to install
 - ` rbenv_root ` - Install path
 - ` rbenv_users ` - Array of Hashes with users for multiuser install. User must be present in the system
+- ` default_gems_file ` - This is Rbenv's plugin _rbenv-default-gems_. Sets the path to a default-gems file of your choice (_don't set it_ if you want to use the default file `files/default-gems`)
 
 Example:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,7 +87,21 @@
   with_items: rbenv_users
   sudo: true
   sudo_user: "{{ item.name }}"
-  when: not "system" == "{{ rbenv.env }}"
+  when:
+    - not "system" == "{{ rbenv.env }}"
+    - default_gems_file is not defined
+  ignore_errors: true
+  tags:
+    - rbenv
+
+- name: set custom default-gems
+  copy: src={{ default_gems_file }} dest={{ item.home }}/.rbenv/default-gems
+  with_items: rbenv_users
+  sudo: true
+  sudo_user: "{{ item.name }}"
+  when:
+    - not "system" == "{{ rbenv.env }}"
+    - default_gems_file is defined
   ignore_errors: true
   tags:
     - rbenv


### PR DESCRIPTION
Specially important if this role is part of multiple playbooks to
provision systems with different Ruby gems requirements.

It is recommended that the roles that have this one as a dependency
should have a `files/default-gems` file stored in it. This is for the
admin's own sanity.
