### PR TITLE
Using fully qualified path to rbenv for user install

### DIFF
--- a/tasks/user_install.yml
+++ b/tasks/user_install.yml
@@ -145,7 +145,7 @@
   check_mode: no
 
 - name: set ruby {{ rbenv.default_ruby }} for select users
-  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && rbenv rehash"
+  shell: $0 -lc "{{ rbenv_root }}/bin/rbenv global {{ rbenv.default_ruby }} && {{ rbenv_root }}/bin/rbenv rehash"
   become: yes
   become_user: "{{ item[1] }}"
   with_together:


### PR DESCRIPTION
Resolves issue where setting the default Ruby version for users was failing with an error like below.

```
TASK [zzet.rbenv : set ruby 2.5.6 for select users] ********************************************************************************************************************************
failed: [neptune] (item=[{'changed': False, 'end': '2019-09-12 23:10:16.341792', 'stdout': '', 'cmd': '$0 -lc "~/.rbenv/bin/rbenv version | cut -d \' \' -f 1 | grep -Fx \'2.5.6\'"', 'failed': False, 'delta': '0:00:00.036825', 'stderr': '', 'rc': 1, 'invocation': {'module_args': {'creates': None, 'executable': None, '_uses_shell': True, 'strip_empty_ends': True, '_raw_params': '$0 -lc "~/.rbenv/bin/rbenv version | cut -d \' \' -f 1 | grep -Fx \'2.5.6\'"', 'removes': None, 'argv': None, 'warn': True, 'chdir': None, 'stdin_add_newline': True, 'stdin': None}}, 'start': '2019-09-12 23:10:16.304967', 'msg': 'non-zero return code', 'stdout_lines': [], 'stderr_lines': [], 'failed_when_result': False, 'item': 'instil', 'ansible_loop_var': 'item'}, 'instil']) => {"ansible_loop_var": "item", "changed": true, "cmd": "$0 -lc \"~/.rbenv/bin/rbenv global 2.5.6 && rbenv rehash\"", "delta": "0:00:00.019968", "end": "2019-09-12 23:10:18.994751", "item": [{"ansible_loop_var": "item", "changed": false, "cmd": "$0 -lc \"~/.rbenv/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '2.5.6'\"", "delta": "0:00:00.036825", "end": "2019-09-12 23:10:16.341792", "failed": false, "failed_when_result": false, "invocation": {"module_args": {"_raw_params": "$0 -lc \"~/.rbenv/bin/rbenv version | cut -d ' ' -f 1 | grep -Fx '2.5.6'\"", "_uses_shell": true, "argv": null, "chdir": null, "creates": null, "executable": null, "removes": null, "stdin": null, "stdin_add_newline": true, "strip_empty_ends": true, "warn": true}}, "item": "instil", "msg": "non-zero return code", "rc": 1, "start": "2019-09-12 23:10:16.304967", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}, "instil"], "msg": "non-zero return code", "rc": 127, "start": "2019-09-12 23:10:18.974783", "stderr": "/bin/sh: rbenv: command not found", "stderr_lines": ["/bin/sh: rbenv: command not found"], "stdout": "", "stdout_lines": []}
```