### PR TITLE
Update rbenv-installer branch name to match source repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ rbenv_plugins:
   - { name: "rbenv-vars",         repo: "https://github.com/rbenv/rbenv-vars.git",         version: "master" }
   - { name: "ruby-build",         repo: "https://github.com/rbenv/ruby-build.git",         version: "master" }
   - { name: "rbenv-default-gems", repo: "https://github.com/rbenv/rbenv-default-gems.git", version: "master" }
-  - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "master" }
+  - { name: "rbenv-installer",    repo: "https://github.com/rbenv/rbenv-installer.git",    version: "main" }
   - { name: "rbenv-update",       repo: "https://github.com/rkh/rbenv-update.git",         version: "master" }
   - { name: "rbenv-whatis",       repo: "https://github.com/rkh/rbenv-whatis.git",         version: "master" }
   - { name: "rbenv-use",          repo: "https://github.com/rkh/rbenv-use.git",            version: "master" }


### PR DESCRIPTION
The [rbenv/rbenv-installer](https://github.com/rbenv/rbenv-installer) project has renamed the primary branch to `main`.

![image](https://user-images.githubusercontent.com/754567/118228479-98377a00-b4cd-11eb-9c4b-0c7e11ab8585.png)

Updating the branch name here will ensure that builds continue to work.

Closes #147 