### PR TITLE
Fix typo about rbenv-installer version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Default variables are:
 
       - { name: "rbenv-installer",
           repo: "https://github.com/rbenv/rbenv-installer.git",
-          version: "master" }
+          version: "main" }
 
       - { name: "rbenv-update",
           repo: "https://github.com/rkh/rbenv-update.git",


### PR DESCRIPTION
By #148, the rbenv-installer version on rbenv_plugins was updated to main.
This commit also updates the rbenv-installer version described in README.